### PR TITLE
Parse ignored topics as empty list when the field is empty

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -332,7 +332,7 @@ class BasePlugin:
         self.mqttserveraddress = Parameters["Address"].replace(" ", "")
         self.mqttserverport = Parameters["Port"].replace(" ", "")
         self.discoverytopic = Parameters["Mode2"]
-        self.ignoredtopics = Parameters["Mode4"].split(',')
+        self.ignoredtopics = Parameters["Mode4"].split(',') if len(Parameters["Mode4"]) != 0 else []
 
         options = ""
         try:
@@ -722,6 +722,7 @@ class BasePlugin:
                     if value.startswith(ignoredtopic):
                         ignore = True
                         Domoticz.Debug("isDeviceIgnored: " + str(ignore))
+                        return ignore
         return ignore
 
     def addTasmotaTopics(self, config):


### PR DESCRIPTION
Also prevent the ignore condition being unnecessarily checked multiple times.